### PR TITLE
Add component uncheck on turret removal

### DIFF
--- a/src/features/turret-header/index.tsx
+++ b/src/features/turret-header/index.tsx
@@ -7,6 +7,8 @@ import {useDispatch} from "react-redux";
 import {removeTurret} from "@/reducers/turret";
 import {Turret} from "@/types";
 import {TurretsMeta} from "@/constants/meta/turrets";
+import {checkboxRemove} from "@/reducers/checkbox";
+import {ComponentType} from "@/constants/enums/components";
 
 type TurretHeaderProps = {
     id: string;
@@ -18,7 +20,11 @@ export function TurretHeader(props: TurretHeaderProps) {
     const dispatch = useDispatch();
 
     function onRemove() {
-        dispatch(removeTurret(props.id))
+        for (const componentType of Object.keys(props.turret.components)) {
+            dispatch(checkboxRemove(componentType as ComponentType));
+        }
+
+        dispatch(removeTurret(props.id));
     }
 
     return (

--- a/src/features/turret-picker/index.tsx
+++ b/src/features/turret-picker/index.tsx
@@ -7,6 +7,9 @@ import {useDispatch, useSelector} from "react-redux";
 import {addTurret, resetTurrets} from "@/reducers/turret";
 import {RootState} from "@/store";
 import {TurretType} from "@/constants/enums/turrets";
+import {uniteComponents} from "@/common/utils/transformations/unite-components";
+import {checkboxRemove} from "@/reducers/checkbox";
+import {ComponentType} from "@/constants/enums/components";
 
 type TurretPickerProps = {
     clearable?: boolean;
@@ -28,6 +31,16 @@ export function TurretPicker(props: TurretPickerProps) {
         if (!selected) return;
 
         dispatch(addTurret(selected));
+    }
+
+    function onResetTurrets() {
+        const components = uniteComponents(turrets);
+
+        for (const componentType of Object.keys(components)) {
+            dispatch(checkboxRemove(componentType as ComponentType));
+        }
+
+        dispatch(resetTurrets())
     }
 
     return (
@@ -57,7 +70,7 @@ export function TurretPicker(props: TurretPickerProps) {
                     <Menu>
                         <MenuItem
                             color="danger"
-                            onClick={() => dispatch(resetTurrets())}
+                            onClick={onResetTurrets}
                             disabled={Object.keys(turrets).length === 0}
                         >
                             <ListItemDecorator>


### PR DESCRIPTION
In both src/features/turret-picker/index.tsx and src/features/turret-header/index.tsx, we now handle the checkbox unchecking when turrets are reset or removed. This was achieved by adding a dispatch call to checkboxRemove from "@/reducers/checkbox" for each componentType in the turrets. The unchecking was not performed prior to this change causing unexpected user experience issues.