### PR TITLE
Add GitHub link to header

### DIFF
--- a/src/common/components/header/index.tsx
+++ b/src/common/components/header/index.tsx
@@ -1,8 +1,9 @@
-import {Container, Link, Option, Select, Stack, Typography,} from "@mui/joy";
+import {Container, IconButton, Link, Option, Select, Stack, Typography} from "@mui/joy";
 import {SyntheticEvent, useContext} from "react";
 import {IntlContext} from "@/contexts/intl";
 import {Link as RouterLink} from 'react-router-dom'
 import {isNull} from "@/common/utils/helpers";
+import {GitHub} from "@mui/icons-material";
 
 type HeaderProps = {
     fontColor?: "black" | "white";
@@ -44,6 +45,11 @@ export function Header(props: HeaderProps) {
                     </Stack>
                 </Stack>
                 <Stack direction="row" spacing={2}>
+                    <Link href="https://github.com/Sovgut/avorion-tools" target="_blank">
+                        <IconButton>
+                            <GitHub />
+                        </IconButton>
+                    </Link>
                     <Select placeholder={intlContext.text("UI", "language")}
                             defaultValue={intlContext.language}
                             onChange={onLanguageChange}


### PR DESCRIPTION
A GitHub icon linking to the project page on GitHub was added to the header component. Users can now easily navigate to the GitHub repository directly from the application.