### PR TITLE
Add disclaimer text for community ownership

### DIFF
--- a/src/features/component-table/index.tsx
+++ b/src/features/component-table/index.tsx
@@ -1,5 +1,5 @@
-import {useContext, useMemo} from "react";
-import {Card, CardOverflow, Divider, Grid, Stack, Table, Tooltip, Typography} from "@mui/joy";
+import React, {useContext, useMemo} from "react";
+import {Card, CardOverflow, Divider, Grid, Link, Stack, Table, Tooltip, Typography} from "@mui/joy";
 import {IntlContext} from "@/contexts/intl";
 import {InfoOutlined as InfoIcon} from "@mui/icons-material"
 import {ComponentItem} from "@/features/component-item";
@@ -49,7 +49,7 @@ export function ComponentTable() {
                 </tbody>
             </Table>
 
-            <CardOverflow variant="soft" color="neutral">
+            <CardOverflow variant="soft" color="neutral" sx={{ borderRadius: 0 }}>
                 <Divider inset="context"/>
                 <Stack spacing={2} sx={{width: "100%", pt: 2, pb: 2}}>
 
@@ -98,6 +98,9 @@ export function ComponentTable() {
                     </Grid>
                 </Stack>
             </CardOverflow>
+            <Stack>
+                <Typography>Avorion Tools is a community work, and not officially created or maintained by <Link href="https://boxelware.de/" target="_blank">Boxelware</Link>.</Typography>
+            </Stack>
         </Card>
     )
 }

--- a/src/pages/getting-started/desktop/index.tsx
+++ b/src/pages/getting-started/desktop/index.tsx
@@ -1,6 +1,6 @@
 import React, {useContext} from "react";
 import {IntlContext} from "@/contexts/intl";
-import {Box, Container, Sheet, Stack, Typography} from "@mui/joy";
+import {Box, Container, Link, Sheet, Stack, Typography} from "@mui/joy";
 import {Header} from "@/common/components/header";
 import styles from './styles.module.css'
 import {TurretPicker} from "@/features/turret-picker";
@@ -90,6 +90,9 @@ export function GettingStartedDesktop() {
                                         className={styles.text}>{intlContext.text("UI", "getting-started-4")}</Typography>
                                 </Stack>
                                 <TurretPicker/>
+                                <Stack>
+                                    <Typography textAlign="center">Avorion Tools is a community work, and not officially created or maintained by <Link href="https://boxelware.de/" target="_blank">Boxelware</Link>.</Typography>
+                                </Stack>
                             </Stack>
                         </Sheet>
                     </Box>


### PR DESCRIPTION
This commit introduces a disclaimer text into the Bottom of the ComponentTable and the GettingStartedOnDesktop pages. A Typography element with the text "Avorion Tools is a community work, and not officially created or maintained by Boxelware" has been added to clarify to users that this is a community project, not an official product of Boxelware. The CardOverflow inside the ComponentTable was also adjusted to have no border radius for a better aesthetic fit.