### PR TITLE
Update layout in Turret Builder and remove min-width style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,1 @@
-body {
-    min-width: 1024px;
-}
+/* GLOBAL STYLES (wow such empty enough) */

--- a/src/pages/turret-builder/index.tsx
+++ b/src/pages/turret-builder/index.tsx
@@ -15,7 +15,7 @@ export function TurretBuilder() {
 
     useLayoutEffect(() => {
         if (!turrets || Object.keys(turrets).length === 0) {
-            navigate("/turret-planner/getting-started", { replace: true });
+            navigate("/turret-planner/getting-started", {replace: true});
         }
     }, [navigate, turrets]);
 
@@ -30,7 +30,7 @@ export function TurretBuilder() {
                         </Grid>
                         <Grid container xs={12}>
                             {Object.keys(turrets).map(id => (
-                                <Grid key={id} xs={6}>
+                                <Grid key={id} sm={6} xs={12}>
                                     <TurretItem id={id} turret={turrets[id]}/>
                                 </Grid>
                             ))}


### PR DESCRIPTION
Update navigation redirection in Turret Builder to fix a misconfiguration and improve readability. Grid key in Turret Builder has been modified to be more responsive on smaller screens. Also, the body min-width property has been removed from the global styles in src/index.css to improve the website's accessibility and responsiveness on smaller screen sizes.