### PR TITLE
Refactor turret-picker component to remove unused text

### DIFF
--- a/src/features/turret-picker/index.tsx
+++ b/src/features/turret-picker/index.tsx
@@ -56,10 +56,8 @@ export function TurretPicker(props: TurretPickerProps) {
                 onClick={onAddTurret}
                 disabled={!selected}
             >
-                <Stack direction="row" sx={{width: "max-content"}} alignItems="center"
-                       spacing={1}>
+                <Stack direction="row" sx={{width: "max-content"}} alignItems="center" spacing={1}>
                     <Add/>
-                    {intlContext.text("UI", "add-turret")}
                 </Stack>
             </Button>
             {props.clearable && (


### PR DESCRIPTION
This commit simplifies the rendering of the 'Add Turret' button within the turret-picker component. The button already includes an 'Add' icon, so the previously visualized text 'add-turret' was removed for a cleaner, more streamlined user interface.