### PR TITLE
Replace useLayoutEffect with useEffect, add scrolling

### DIFF
--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect} from "react";
+import {useEffect} from "react";
 import {useNavigate} from 'react-router-dom';
 
 import {GettingStartedDesktop} from "./desktop";
@@ -14,8 +14,9 @@ export function GettingStartedPage() {
     const turrets = useSelector((state: RootState) => state.turret);
     const isSmallScreen = useMediaQuery({query: `(max-width: ${theme.breakpoints.values.md}px)`});
 
-    useLayoutEffect(() => {
+    useEffect(() => {
         if (turrets && Object.keys(turrets).length > 0) {
+            window.scrollTo(0, 0);
             navigate("/turret-planner", {replace: true});
         }
     }, [navigate, turrets]);

--- a/src/pages/turret-planner/index.tsx
+++ b/src/pages/turret-planner/index.tsx
@@ -1,5 +1,5 @@
 import {Box, Container} from "@mui/joy";
-import React, {Fragment, useLayoutEffect} from "react";
+import React, {Fragment, useEffect} from "react";
 import {Header} from "@/common/components/header";
 import {useNavigate} from "react-router-dom";
 import {useSelector} from "react-redux";
@@ -15,8 +15,9 @@ export function TurretPlannerPage() {
     const navigate = useNavigate();
     const turrets = useSelector((state: RootState) => state.turret);
 
-    useLayoutEffect(() => {
+    useEffect(() => {
         if (!turrets || Object.keys(turrets).length === 0) {
+            window.scrollTo(0, 0);
             navigate("/turret-planner/getting-started", {replace: true});
         }
     }, [navigate, turrets]);


### PR DESCRIPTION
Replaced useLayoutEffect hooks with useEffect in 'turret-planner' and 'getting-started' files to ensure better performance. Also added 'window.scrollTo' function to scroll the user view to top of the page on component mount. This provides a more user-friendly experience during navigation.