### PR TITLE
Adjust dropdown menu placement

### DIFF
--- a/src/features/turret-header/index.tsx
+++ b/src/features/turret-header/index.tsx
@@ -36,7 +36,7 @@ export function TurretHeader(props: TurretHeaderProps) {
                 </Stack>
                 <Dropdown>
                     <MenuButton sx={{width: "44px", height: "40px"}}><MoreIcon/></MenuButton>
-                    <Menu>
+                    <Menu placement="bottom-end">
                         <MenuItem color="danger" onClick={onRemove}>{intlContext.text("UI", "remove-turret")}</MenuItem>
                     </Menu>
                 </Dropdown>

--- a/src/features/turret-picker/index.tsx
+++ b/src/features/turret-picker/index.tsx
@@ -65,7 +65,7 @@ export function TurretPicker(props: TurretPickerProps) {
                     <MenuButton variant="solid" color="primary">
                         <ArrowDropDown/>
                     </MenuButton>
-                    <Menu>
+                    <Menu placement="bottom-end">
                         <MenuItem
                             color="danger"
                             onClick={onResetTurrets}


### PR DESCRIPTION
Adjusted the placement of dropdown menus in 'turret-header' and 'turret-picker' components from default to "bottom-end". This modification improves UI aesthetics and usability by ensuring that the dropdown menu does not cover other elements on the screen.