### PR TITLE
Add hidden Numeric components for five turret components

### DIFF
--- a/src/features/turret-components/index.tsx
+++ b/src/features/turret-components/index.tsx
@@ -1,5 +1,5 @@
 import {Stack} from "@mui/joy";
-import {useContext} from "react";
+import {Fragment, useContext} from "react";
 import {IntlContext} from "@/contexts/intl";
 import {Numeric} from "common/components/numeric";
 import {MAX_COMPONENT_QUANTITY} from "@/constants/common";
@@ -39,6 +39,19 @@ export function TurretComponents({id, turret}: Props) {
                     value={turret.components[component]}
                     onChange={onComponentChange}/>
             ))}
+
+            {components.length === 5 &&
+                <Fragment>
+                    <Numeric
+                        id={nanoid()}
+                        label={String()}
+                        hidden/>
+                    <Numeric
+                        id={nanoid()}
+                        label={String()}
+                        hidden/>
+                </Fragment>
+            }
 
             {components.length === 6 &&
                 <Numeric


### PR DESCRIPTION
The `Fragment` and extra `Numeric` components were added to the `turret-components` index file to handle situations where there are five components. These additional hidden components help maintain consistent functionality and layout when the components length equals five.