### PR TITLE
Improve visibility of hidden numeric component

### DIFF
--- a/src/common/components/numeric/index.tsx
+++ b/src/common/components/numeric/index.tsx
@@ -80,7 +80,7 @@ export function Numeric(props: NumericProps) {
                     onFocus: handleFocus,
                 }
             }}
-            sx={{opacity: props.hidden ? '0' : '1'}}
+            sx={{opacity: props.hidden ? '0.75' : '1'}}
             disabled={props.hidden}
             onChange={handleChange}
             onClick={handleClick}


### PR DESCRIPTION
The opacity of the 'hidden' state in the numeric component has been updated from '0' to '0.75'. This was done to increase its visibility even when the component is set to hidden, making it more user-friendly.