### PR TITLE
Add transition animation to page changes

### DIFF
--- a/src/features/turret-picker/index.tsx
+++ b/src/features/turret-picker/index.tsx
@@ -45,8 +45,17 @@ export function TurretPicker(props: TurretPickerProps) {
 
     return (
         <Stack direction="row" spacing={1}>
-            <Select value={selected} onChange={(e, v) => onSelectTurret(v)}
-                    sx={{width: "100%"}}>
+            <Select value={selected}
+                    onChange={(e, v) => onSelectTurret(v)}
+                    sx={{width: "100%"}}
+                    slotProps={{
+                        listbox: {
+                            sx: {
+                                maxHeight: '300px',
+                            },
+                        },
+                    }}
+            >
                 {Object.values(TurretType).map(turret => (
                     <Option key={turret}
                             value={turret}>{intlContext.text("TURRET", turret as TurretType)}</Option>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,9 +42,7 @@ const router = createBrowserRouter([
             },
             {
                 path: "getting-started",
-                element: (
-                    <GettingStartedPage/>
-                )
+                element: <GettingStartedPage/>
             },
         ],
     },

--- a/src/layouts/getting-started/styles.module.css
+++ b/src/layouts/getting-started/styles.module.css
@@ -4,5 +4,5 @@
     min-width: 100vw;
     top: 0;
     left: 0;
-    z-index: -1;
+    z-index: 1;
 }

--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {useNavigate} from 'react-router-dom';
 import {useSelector} from "react-redux";
 import {RootState} from "@/store";
@@ -7,28 +7,47 @@ import {Header} from "@/common/components/header";
 import {VideoBackground} from "@/common/components/video-background";
 import {GettingStartedLayout} from "@/layouts/getting-started";
 import {TurretPicker} from "@/features/turret-picker";
+import styles from './styles.module.css'
+import {clsx} from "clsx";
 
 export function GettingStartedPage() {
+    const [isClosePage, setClose] = useState(false);
+
     const navigate = useNavigate();
     const turrets = useSelector((state: RootState) => state.turret);
 
     useEffect(() => {
         if (turrets && Object.keys(turrets).length > 0) {
-            window.scrollTo(0, 0);
-            navigate("/turret-planner", {replace: true});
+            setClose(true);
+
+            const timeoutId = setTimeout(() => {
+                window.scrollTo(0, 0);
+                navigate("/turret-planner", {replace: true});
+            }, 300);
+
+            return function cleanup() {
+                clearTimeout(timeoutId);
+            }
         }
     }, [navigate, turrets]);
 
+    const componentClasses = clsx({
+        [styles.component]: true,
+        [styles.close]: isClosePage,
+    });
+
     return (
-        <Box>
-            <Header/>
+        <Box className={componentClasses} sx={{minHeight: "100vh"}}>
+            <Box sx={{position: "relative", zIndex: 2}}>
+                <Header/>
+            </Box>
 
             <GettingStartedLayout>
                 <VideoBackground/>
 
                 <Box sx={{
                     minHeight: "100vh",
-                    minWidth: "100%",
+                    minWidth: "100vw",
                     display: "flex",
                     justifyContent: "center",
                     alignItems: "center",
@@ -40,7 +59,8 @@ export function GettingStartedPage() {
                             <Card sx={{boxShadow: "sm"}}>
                                 <TurretPicker/>
                                 <Typography level="body-sm">
-                                    <b>Avorion Tools</b> is a community work, and not officially created or maintained
+                                    <b>Avorion Tools</b> is a community work, and not officially created or
+                                    maintained
                                     by <Link
                                     href="https://boxelware.de/" target="_blank">Boxelware</Link>.
                                 </Typography>

--- a/src/pages/getting-started/styles.module.css
+++ b/src/pages/getting-started/styles.module.css
@@ -1,0 +1,31 @@
+@keyframes OpenPage {
+    from {
+        opacity: 0;
+        transform: scale(95%);
+    }
+    to {
+        opacity: 1;
+        transform: scale(100%);
+    }
+}
+
+@keyframes ClosePage {
+    to {
+        opacity: 0;
+        transform: scale(95%);
+    }
+    from {
+        opacity: 1;
+        transform: scale(100%);
+    }
+}
+
+.component {
+    animation: OpenPage;
+    animation-duration: 300ms;
+}
+
+.component.close {
+    animation: ClosePage;
+    animation-duration: 300ms;
+}

--- a/src/pages/turret-planner/index.tsx
+++ b/src/pages/turret-planner/index.tsx
@@ -1,29 +1,45 @@
 import {Box, Container} from "@mui/joy";
-import React, {Fragment, useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {Header} from "@/common/components/header";
 import {useNavigate} from "react-router-dom";
 import {useSelector} from "react-redux";
 import {RootState} from "@/store";
 import {TurretPicker} from "@/features/turret-picker";
 import {VideoBackground} from "@/common/components/video-background";
-import styles from './styles.module.css';
 import {TurretItem} from "@/features/turret-item";
 import {ComponentsTable} from "@/components/components-table";
 import {CargoTable} from "@/components/cargo-table";
+import {clsx} from "clsx";
+import styles from './styles.module.css';
 
 export function TurretPlannerPage() {
+    const [isClosePage, setClose] = useState(false);
+
     const navigate = useNavigate();
     const turrets = useSelector((state: RootState) => state.turret);
 
     useEffect(() => {
         if (!turrets || Object.keys(turrets).length === 0) {
-            window.scrollTo(0, 0);
-            navigate("/turret-planner/getting-started", {replace: true});
+            setClose(true);
+
+            const timeoutId = setTimeout(() => {
+                window.scrollTo(0, 0);
+                navigate("/turret-planner/getting-started", {replace: true});
+            }, 300);
+
+            return function cleanup() {
+                clearTimeout(timeoutId);
+            }
         }
     }, [navigate, turrets]);
 
+    const componentClasses = clsx({
+        [styles.component]: true,
+        [styles.close]: isClosePage,
+    });
+
     return (
-        <Fragment>
+        <Box className={componentClasses}>
             <VideoBackground/>
             <Container maxWidth={false} sx={{pb: 2}} className={styles.desktop}>
                 <Header disableGutters/>
@@ -43,6 +59,6 @@ export function TurretPlannerPage() {
                     </Box>
                 </Box>
             </Container>
-        </Fragment>
+        </Box>
     )
 }

--- a/src/pages/turret-planner/styles.module.css
+++ b/src/pages/turret-planner/styles.module.css
@@ -1,3 +1,38 @@
+@keyframes OpenPage {
+    from {
+        opacity: 0;
+        transform: scale(95%);
+    }
+    to {
+        opacity: 1;
+        transform: scale(100%);
+    }
+}
+
+@keyframes ClosePage {
+    to {
+        opacity: 0;
+        transform: scale(95%);
+    }
+    from {
+        opacity: 1;
+        transform: scale(100%);
+    }
+}
+
+.component {
+    animation: OpenPage;
+    animation-duration: 300ms;
+
+    min-height: 100vh;
+    min-width: 100vw;
+}
+
+.component.close {
+    animation: ClosePage;
+    animation-duration: 300ms;
+}
+
 .desktop .layout {
     display: flex;
     padding-top: 8px;


### PR DESCRIPTION
Introduced a transition animation when switching between the turret planner page and the getting started page to enhance the user experience. The animation consists of a fade-out/fade-in and a slight scale transition. This was achieved by introducing local state to manage the animation and utilizing the 'clsx' library for merging CSS classes. Furthermore, adjustments were made to the select drop-down within the turret picker component for a better display of options.