### PR TITLE
Add i18n support to 'Getting Started' page

### DIFF
--- a/src/components/components-table/index.tsx
+++ b/src/components/components-table/index.tsx
@@ -73,7 +73,7 @@ export function ComponentsTable() {
             </CardOverflow>
             <Box sx={{p: 1}}>
                 <Typography level="body-sm">
-                    Avorion Tools is a community work, and not officially created or maintained by <Link
+                    <b>Avorion Tools</b> is a community work, and not officially created or maintained by <Link
                     href="https://boxelware.de/" target="_blank">Boxelware</Link>.
                 </Typography>
             </Box>

--- a/src/contexts/intl/storage/languages/en-US/index.ts
+++ b/src/contexts/intl/storage/languages/en-US/index.ts
@@ -4,6 +4,7 @@ import {SellerType} from "@/constants/enums/sellers";
 import {IntlComponent, IntlSeller, IntlTurret, IntlUI} from "@/contexts/intl/storage/types";
 
 const UI: IntlUI = {
+    "lets-add-turret": "Let's add your first recipe to Turret planner!",
     "cargo-offset": "Cargo offset",
     "guaranteed-in": "Guaranteed in",
     "can-be-found-in": "Can be found in",

--- a/src/contexts/intl/storage/languages/ru/index.ts
+++ b/src/contexts/intl/storage/languages/ru/index.ts
@@ -4,6 +4,7 @@ import {SellerType} from "@/constants/enums/sellers";
 import {IntlComponent, IntlSeller, IntlTurret, IntlUI} from "@/contexts/intl/storage/types";
 
 const UI: IntlUI = {
+    "lets-add-turret": "Давайте добавим ваш первый рецепт в планировщик турелей!",
     "cargo-offset": "Наличие в трюме",
     "guaranteed-in": "Гарантировано содержится в",
     "can-be-found-in": "Может содержаться в",

--- a/src/contexts/intl/storage/types.ts
+++ b/src/contexts/intl/storage/types.ts
@@ -109,6 +109,7 @@ export interface IntlComponent {
 }
 
 export interface IntlUI {
+    "lets-add-turret": string;
     "cargo-offset": string;
     "guaranteed-in": string;
     "can-be-found-in": string;

--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {useNavigate} from 'react-router-dom';
 import {useSelector} from "react-redux";
 import {RootState} from "@/store";
@@ -9,10 +9,12 @@ import {GettingStartedLayout} from "@/layouts/getting-started";
 import {TurretPicker} from "@/features/turret-picker";
 import styles from './styles.module.css'
 import {clsx} from "clsx";
+import {IntlContext} from "@/contexts/intl";
 
 export function GettingStartedPage() {
     const [isClosePage, setClose] = useState(false);
 
+    const intlContext = useContext(IntlContext);
     const navigate = useNavigate();
     const turrets = useSelector((state: RootState) => state.turret);
 
@@ -54,8 +56,8 @@ export function GettingStartedPage() {
                 }}>
                     <Container>
                         <Stack spacing={4}>
-                            <Typography level="h1" textAlign="center">Let's add your first recipe to Turret
-                                planner!</Typography>
+                            <Typography level="h1"
+                                        textAlign="center">{intlContext.text("UI", "lets-add-turret")}</Typography>
                             <Card sx={{boxShadow: "sm"}}>
                                 <TurretPicker/>
                                 <Typography level="body-sm">


### PR DESCRIPTION
The 'Getting Started' page was updated to support internationalization. Imports for useContext was added while hard-coded strings were replaced with keys defined in the Intl context. Accompanying language strings were added in 'IntlUI' for both English and Russian. Additionally, some minor cosmetic changes were made i.e. 'Avorion Tools' was stylized with bold typography in ComponentsTable for emphasis.