### PR TITLE
Align icons to the center in cargo and component table

### DIFF
--- a/src/components/cargo-table/cargo-type/index.tsx
+++ b/src/components/cargo-table/cargo-type/index.tsx
@@ -24,7 +24,7 @@ export function CargoItemType(props: Props) {
 
     return (
         <td style={{paddingRight: 0}}>
-            <Stack direction="row" spacing={1}>
+            <Stack direction="row" spacing={1} alignItems="center">
                 <img className={styles.icon}
                      src={ComponentsMeta[props.type].icon}
                      alt={intlContext.text("COMPONENT", props.type)}/>

--- a/src/components/components-table/component-type/index.tsx
+++ b/src/components/components-table/component-type/index.tsx
@@ -50,7 +50,7 @@ export function ComponentItemType(props: Props) {
                 </Box>
             </td>
             <td onClick={handleCheckbox} style={{paddingLeft: 0, paddingRight: 0}}>
-                <Stack direction="row" spacing={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
                     <img className={styles.icon}
                          src={ComponentsMeta[props.type].icon}
                          alt={intlContext.text("COMPONENT", props.type)}/>


### PR DESCRIPTION
The alignItems property was added to Stack component in cargo-type and component-type files. This was done to ensure that the icons are centered properly, improving the visual layout and readability of the user interface.