### PR TITLE
Add reset components functionality for turrets

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2,6 +2,7 @@ export const MAX_TURRET_QUANTITY = 999_999;
 export const MIN_TURRET_QUANTITY = 1;
 export const MAX_TURRET_PRICE = 9_999_999_999;
 export const MIN_TURRET_PRICE = 0;
+export const MIN_COMPONENT_PRICE = 0;
 export const MAX_COMPONENT_QUANTITY = 9_999_999;
 export const MAX_PRICE_PERCENTAGE = 3.00;
 export const MAX_CARGO_QUANTITY = 9_999_999;

--- a/src/contexts/intl/storage/languages/en-US/index.ts
+++ b/src/contexts/intl/storage/languages/en-US/index.ts
@@ -23,6 +23,7 @@ const UI: IntlUI = {
     "cargo-field-note": "Whenever the quantity of the component-components-table is modified, the cargo value is automatically reset to its default state.",
     "cargo-field-label": "Add",
     "add-turret": "Add turret",
+    "reset-components": "Reset components",
     "remove-turret": "Remove turret",
     "turret-price": "Price",
     "clear-turrets": "Clear turrets",

--- a/src/contexts/intl/storage/languages/ru/index.ts
+++ b/src/contexts/intl/storage/languages/ru/index.ts
@@ -24,6 +24,7 @@ const UI: IntlUI = {
     "cargo-field-label": "Добавить",
     "add-turret": "Добавить турель",
     "remove-turret": "Удалить турель",
+    "reset-components": "Сбросить компоненты",
     "clear-turrets": "Очистить турели",
     "turret-price": "Цена",
     "clear-turrets-confirmation": "Вы уверены, что хотите очистить список турелей?",

--- a/src/contexts/intl/storage/types.ts
+++ b/src/contexts/intl/storage/types.ts
@@ -128,6 +128,7 @@ export interface IntlUI {
     "cargo-field-note": string;
     "cargo-field-label": string;
     "add-turret": string;
+    "reset-components": string;
     "remove-turret": string;
     "clear-turrets": string;
     "clear-turrets-confirmation": string;

--- a/src/features/turret-header/index.tsx
+++ b/src/features/turret-header/index.tsx
@@ -1,14 +1,15 @@
 import {useContext} from "react";
 import {MoreVert as MoreIcon} from "@mui/icons-material";
 import {IntlContext} from "@/contexts/intl";
-import {Box, Dropdown, Menu, MenuButton, MenuItem, Stack, Typography} from "@mui/joy";
+import {Box, Divider, Dropdown, Menu, MenuButton, MenuItem, Stack, Typography} from "@mui/joy";
 import styles from "./styles.module.css";
 import {useDispatch} from "react-redux";
-import {removeTurret} from "@/reducers/turret";
+import {removeTurret, updateComponent, updateTurret} from "@/reducers/turret";
 import {Turret} from "@/types";
 import {TurretsMeta} from "@/constants/meta/turrets";
 import {checkboxRemove} from "@/reducers/checkbox";
 import {ComponentType} from "@/constants/enums/components";
+import {MIN_COMPONENT_PRICE, MIN_TURRET_PRICE, MIN_TURRET_QUANTITY} from "@/constants/common";
 
 type TurretHeaderProps = {
     id: string;
@@ -27,6 +28,25 @@ export function TurretHeader(props: TurretHeaderProps) {
         dispatch(removeTurret(props.id));
     }
 
+    function handleResetFields() {
+        dispatch(updateTurret({
+            id: props.id,
+            data: {
+                ...props.turret,
+                price: MIN_TURRET_PRICE,
+                quantity: MIN_TURRET_QUANTITY,
+            }
+        }))
+
+        for (const componentType of Object.keys(props.turret.components)) {
+            dispatch(updateComponent({
+                type: componentType as ComponentType,
+                turretId: props.id,
+                data: MIN_COMPONENT_PRICE,
+            }));
+        }
+    }
+
     return (
         <Box>
             <Stack direction="row" justifyContent="space-between">
@@ -37,6 +57,8 @@ export function TurretHeader(props: TurretHeaderProps) {
                 <Dropdown>
                     <MenuButton variant="plain" sx={{width: "44px", height: "40px"}}><MoreIcon/></MenuButton>
                     <Menu placement="bottom-end">
+                        <MenuItem onClick={handleResetFields}>{intlContext.text("UI", "reset-components")}</MenuItem>
+                        <Divider/>
                         <MenuItem color="danger" onClick={onRemove}>{intlContext.text("UI", "remove-turret")}</MenuItem>
                     </Menu>
                 </Dropdown>


### PR DESCRIPTION
A reset components option has been implemented to allow users to reset all of a turret's components to their defaults. This commit updates the functions in 'turret-header/index.tsx' to include the 'reset-components' action. Localization strings for this option in both English and Russian are added in 'contexts/intl/storage/languages/' directories. A minimum component price constant is also added in 'constants/common.ts'.