### PR TITLE
Remove minHeight style from Box component and styles.module.css

### DIFF
--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -39,7 +39,7 @@ export function GettingStartedPage() {
     });
 
     return (
-        <Box className={componentClasses} sx={{minHeight: "100vh"}}>
+        <Box className={componentClasses}>
             <Box sx={{position: "relative", zIndex: 2}}>
                 <Header/>
             </Box>

--- a/src/pages/turret-planner/styles.module.css
+++ b/src/pages/turret-planner/styles.module.css
@@ -23,9 +23,6 @@
 .component {
     animation: OpenPage;
     animation-duration: 150ms;
-
-    min-height: 100vh;
-    min-width: 100vw;
 }
 
 .component.close {


### PR DESCRIPTION
The minHeight style property was removed from the Box component in getting-started/index.tsx and styles.module.css in turret-planner. The change was needed as it was causing layout issues on smaller screens. Now, the Box component and turret-planner page will automatically adjust their heights based on the content inside them, providing a more adaptive UI across different screen sizes.