### PR TITLE
Update video background sizing units

### DIFF
--- a/src/components/video-background/index.tsx
+++ b/src/components/video-background/index.tsx
@@ -56,7 +56,7 @@ export function VideoBackground() {
     }
 
     return (
-        <Box sx={{display: "flex", position: "fixed", height: "100%", width: "100%", zIndex: "-1"}}>
+        <Box sx={{display: "flex", position: "fixed", height: "100vh", width: "100vw", zIndex: "-1"}}>
             <Box sx={{
                 top: 0,
                 left: 0,


### PR DESCRIPTION
Changed the height and width units in video background from percentage to viewport height (vh) and viewport width (vw) for better responsiveness and to maintain aspect ratio across different devices. Ensures video background scales appropriately with the change in screen size.