### PR TITLE
Update position and sizing of elements in Getting Started page

### DIFF
--- a/src/layouts/getting-started/styles.module.css
+++ b/src/layouts/getting-started/styles.module.css
@@ -1,8 +1,5 @@
 .component {
-    position: absolute;
-    min-height: 100vh;
-    min-width: 100vw;
-    top: 0;
-    left: 0;
+    position: relative;
+    height: 100%;
     z-index: 1;
 }

--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -40,7 +40,7 @@ export function GettingStartedPage() {
 
     return (
         <Box className={componentClasses}>
-            <Box sx={{position: "relative", zIndex: 2}}>
+            <Box sx={{position: "fixed", width: "100%", zIndex: 2}}>
                 <Header/>
             </Box>
 
@@ -48,8 +48,7 @@ export function GettingStartedPage() {
                 <VideoBackground/>
 
                 <Box sx={{
-                    minHeight: "100vh",
-                    minWidth: "100vw",
+                    height: "100%",
                     display: "flex",
                     justifyContent: "center",
                     alignItems: "center",

--- a/src/pages/getting-started/styles.module.css
+++ b/src/pages/getting-started/styles.module.css
@@ -23,6 +23,8 @@
 .component {
     animation: OpenPage;
     animation-duration: 150ms;
+
+    height: 100vh;
 }
 
 .component.close {


### PR DESCRIPTION
The changes update the CSS properties of selected elements on the Getting Started page. The position of the Box component was changed from relative to fixed with full width coverage to ensure it stays on top of the viewport during scrolling. The minimum height and width of the Box and the component class in the CSS modules were changed to "100%" to better fit, adapt, and cover the entire space of the parent container. The height of the component class in the Getting Started CSS module was set to "100vh" to ensure the component takes the full height of the viewport. These changes improve responsiveness and adaptability of the page layout.