### PR TITLE
Add 'react-viewport-height' to handle screen height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-router": "^6.14.2",
         "react-router-dom": "^6.14.2",
         "react-scripts": "5.0.1",
+        "react-viewport-height": "^1.2.2",
         "styled-components": "^5.3.11",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -13849,6 +13850,19 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-viewport-height": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-viewport-height/-/react-viewport-height-1.2.2.tgz",
+      "integrity": "sha512-bfDA+jcZyk9OxnevEe2Ll8zZJ/KDX99Xl9Sa7VScboO0ReVpepZV9a9MITO6gZ2XD2/0ovryFBr5ZcOdB5Lu1Q==",
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/dimazuien"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-router": "^6.14.2",
     "react-router-dom": "^6.14.2",
     "react-scripts": "5.0.1",
+    "react-viewport-height": "^1.2.2",
     "styled-components": "^5.3.11",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/video-background/index.tsx
+++ b/src/components/video-background/index.tsx
@@ -2,8 +2,11 @@ import {Box} from "@mui/joy";
 import React, {Fragment} from "react";
 import {useTheme} from "@mui/joy/styles";
 import {useMediaQuery} from "react-responsive";
+import useVH from 'react-viewport-height';
 
 export function VideoBackground() {
+    const vh = useVH();
+
     const theme = useTheme();
     const isSmallScreen = useMediaQuery({query: `(max-width: ${theme.breakpoints.values.md}px)`});
     let element = (
@@ -56,7 +59,7 @@ export function VideoBackground() {
     }
 
     return (
-        <Box sx={{display: "flex", position: "fixed", height: "100dvh", width: "100dvw", zIndex: "-1"}}>
+        <Box style={{height: `${100 * vh}px`, width: "100%"}} sx={{display: "flex", position: "fixed", zIndex: "-1"}}>
             <Box sx={{
                 top: 0,
                 left: 0,


### PR DESCRIPTION
A library called 'react-viewport-height' was added to correctly handle different viewport heights across devices. This was necessary because a solution that relies purely on CSS (e.g. using 'vh') is often inconsistent between devices. In the video background component, this library was used to determine the height of the box containing the video.