### PR TITLE
"Implement viewport height calculation in Getting Started page

### DIFF
--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -10,10 +10,12 @@ import {IntlContext} from "@/contexts/intl";
 import {TurretPicker} from "@/components/turret-picker";
 import {Header} from "components/header";
 import {VideoBackground} from "components/video-background";
+import useVH from "react-viewport-height";
 
 export function GettingStartedPage() {
     const [isClosePage, setClose] = useState(false);
 
+    const vh = useVH();
     const intlContext = useContext(IntlContext);
     const navigate = useNavigate();
     const turrets = useSelector((state: RootState) => state.turret);
@@ -39,7 +41,7 @@ export function GettingStartedPage() {
     });
 
     return (
-        <Box className={componentClasses}>
+        <Box className={componentClasses} style={{height: `${100 * vh}px`, width: "100%"}}>
             <Box sx={{position: "fixed", width: "100%", zIndex: 2}}>
                 <Header/>
             </Box>

--- a/src/pages/getting-started/styles.module.css
+++ b/src/pages/getting-started/styles.module.css
@@ -23,8 +23,6 @@
 .component {
     animation: OpenPage;
     animation-duration: 150ms;
-
-    height: 100vh;
 }
 
 .component.close {


### PR DESCRIPTION
The commit introduces the dynamic viewport height calculation in the Getting Started page for better page height management. The viewport height is calculated by the react-viewport-height hook, and it is applied onto Box component inside the page. It also removes the static viewport height value from the CSS file. This change is useful for proper page rendering across different device heights."