### PR TITLE
Increase video-background height to 120%

### DIFF
--- a/src/components/video-background/styles.module.css
+++ b/src/components/video-background/styles.module.css
@@ -3,7 +3,7 @@
     left: 0;
     position: fixed;
     z-index: -3;
-    height: 100%;
+    height: 120%;
     width: 100%;
     overflow: hidden;
 


### PR DESCRIPTION
The video background component's height has been increased from 100% to 120% to better cover high-resolution screens. It helps in avoiding any white space at the bottom of the page and enhancing user visual experience.