### PR TITLE
Remove video background component

### DIFF
--- a/src/components/video-background/index.tsx
+++ b/src/components/video-background/index.tsx
@@ -1,29 +1,31 @@
-import {Box} from "@mui/joy";
-import React from "react";
-import {useTheme} from "@mui/joy/styles";
-import {useMediaQuery} from "react-responsive";
-import styles from './styles.module.css';
+// import {Box} from "@mui/joy";
+// import React from "react";
+// import {useTheme} from "@mui/joy/styles";
+// import {useMediaQuery} from "react-responsive";
+// import styles from './styles.module.css';
 
 export function VideoBackground() {
-    const theme = useTheme();
-    const isSmallScreen = useMediaQuery({query: `(max-width: ${theme.breakpoints.values.md}px)`});
+    // const theme = useTheme();
+    // const isSmallScreen = useMediaQuery({query: `(max-width: ${theme.breakpoints.values.md}px)`});
 
-    return (
-        <Box className={styles.container}>
-            {!isSmallScreen && <video
-                style={{
-                    position: "absolute",
-                    width: "100%",
-                    height: "100%",
-                    top: "0",
-                    left: "0",
-                    objectFit: "cover",
-                }}
-                src={`/assets/video/dark-background.mp4`}
-                autoPlay
-                loop
-                muted
-                controls={false}/>}
-        </Box>
-    )
+    return null;
+
+    // return (
+    //     <Box className={styles.container}>
+    //         {!isSmallScreen && <video
+    //             style={{
+    //                 position: "absolute",
+    //                 width: "100%",
+    //                 height: "100%",
+    //                 top: "0",
+    //                 left: "0",
+    //                 objectFit: "cover",
+    //             }}
+    //             src={`/assets/video/dark-background.mp4`}
+    //             autoPlay
+    //             loop
+    //             muted
+    //             controls={false}/>}
+    //     </Box>
+    // )
 }

--- a/src/components/video-background/styles.module.css
+++ b/src/components/video-background/styles.module.css
@@ -1,33 +1,33 @@
-.container {
-    height: 0;
-    position: relative;
-}
+/*.container {*/
+/*    height: 0;*/
+/*    position: relative;*/
+/*}*/
 
-.container::before {
-    content: "";
-    position: fixed;
-    height: 100vh;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: -2;
+/*.container::before {*/
+/*    content: "";*/
+/*    position: fixed;*/
+/*    height: 100vh;*/
+/*    top: 0;*/
+/*    right: 0;*/
+/*    bottom: 0;*/
+/*    left: 0;*/
+/*    z-index: -2;*/
 
-    background-image: url("../../../public/assets/img/dark-background.webp");
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
-}
+/*    background-image: url("../../../public/assets/img/dark-background.webp");*/
+/*    background-repeat: no-repeat;*/
+/*    background-size: cover;*/
+/*    background-position: center;*/
+/*}*/
 
-.container::after,
-.container video::after {
-    content: "";
-    top: 0;
-    left: 0;
-    position: fixed;
-    z-index: -1;
-    height: 100vh;
-    width: 100%;
-    background: linear-gradient(to bottom, transparent, #23272B);
-    opacity: .75;
-}
+/*.container::after,*/
+/*.container video::after {*/
+/*    content: "";*/
+/*    top: 0;*/
+/*    left: 0;*/
+/*    position: fixed;*/
+/*    z-index: -1;*/
+/*    height: 100vh;*/
+/*    width: 100%;*/
+/*    background: linear-gradient(to bottom, transparent, #23272B);*/
+/*    opacity: .75;*/
+/*}*/

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,20 @@ html, body {
     position: relative;
     z-index: -999;
 }
+
+body:after {
+    content: "";
+    position: fixed; /* stretch a fixed position to the whole screen */
+    height: 100vh; /* fix for mobile browser address bar appearing disappearing */
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: -1; /* needed to keep in the background */
+    background-image: url("/public/assets/img/dark-background.webp");
+    background-repeat: no-repeat;
+    background-position: center;
+    -webkit-background-size: cover;
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
+}


### PR DESCRIPTION
The video background component has been removed as deemed unnecessary for our current layout. All accompanying styles which were found in 'styles.module.css' have been commented out. Instead, we've added a static background image to 'index.css' for uniformity on all screens. This change reflects our aim to optimize performance and simplify the design for better user experience.