### PR TITLE
Fix height property value in CSS files

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@ html, body {
 body:after {
     content: "";
     position: fixed; /* stretch a fixed position to the whole screen */
-    height: 100lvh; /* fix for mobile browser address bar appearing disappearing */
+    height: 100vh; /* fix for mobile browser address bar appearing disappearing */
     top: 0;
     left: 0;
     right: 0;
@@ -28,7 +28,7 @@ body::before {
     left: 0;
     position: fixed;
     z-index: -997;
-    height: 100lvh;
+    height: 100vh;
     width: 100%;
     background: linear-gradient(to bottom, transparent, #23272B);
     opacity: .75;

--- a/src/pages/getting-started/styles.module.css
+++ b/src/pages/getting-started/styles.module.css
@@ -24,7 +24,7 @@
     animation: OpenPage;
     animation-duration: 150ms;
 
-    height: 100lvh;
+    height: 100vh;
 }
 
 .animation.close {


### PR DESCRIPTION
Corrected the invalid CSS property value from '100lvh' to '100vh' in the 'styles.module.css' and 'index.css' files. This was causing inaccurate rendering of page height across different elements. Now, all elements will accurately take up 100% of the viewport height.