### PR TITLE
Add max height to turret picker dropdown

### DIFF
--- a/src/components/turret-picker/index.tsx
+++ b/src/components/turret-picker/index.tsx
@@ -17,7 +17,18 @@ export function TurretPicker() {
     }
 
     return (
-        <Select placeholder={intlContext.text("UI", "select-turret")} onChange={handleSelect} value={null}>
+        <Select
+            placeholder={intlContext.text("UI", "select-turret")}
+            onChange={handleSelect}
+            value={null}
+            slotProps={{
+                listbox: {
+                    sx: {
+                        maxHeight: "200px"
+                    }
+                }
+            }}
+        >
             {turrets.map(turret => <Option key={turret} value={turret}>{intlContext.text("TURRET", turret)}</Option>)}
         </Select>
     )

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-/* GLOBAL STYLES (wow such empty enough) */
 html, body {
     background-color: #100e21;
     position: relative;


### PR DESCRIPTION
The height of the dropdown in the turret picker component was updated to ensure better user experience. The max height of the dropdown list was set to 200px to prevent it from occupying too much screen space when displaying a long list of options. A code comment has also been removed from the global styles.