### PR TITLE
Update CSS to support dynamic heights

### DIFF
--- a/src/layouts/getting-started/styles.module.css
+++ b/src/layouts/getting-started/styles.module.css
@@ -2,4 +2,13 @@
     position: relative;
     height: 100%;
     z-index: 1;
+
+    padding-top: 12rem;
+}
+
+@supports (height: 100svh) {
+    .component {
+        height: 100svh;
+        padding-top: 0;
+    }
 }

--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -38,7 +38,7 @@ export function GettingStartedPage() {
     });
 
     return (
-        <Box sx={{height: "100lvh"}}>
+        <Box>
             <Box sx={{position: "fixed", width: "100%", zIndex: 2}}>
                 <Header/>
             </Box>

--- a/src/pages/getting-started/styles.module.css
+++ b/src/pages/getting-started/styles.module.css
@@ -24,7 +24,7 @@
     animation: OpenPage;
     animation-duration: 150ms;
 
-    height: 100vh;
+    height: 100%;
 }
 
 .animation.close {


### PR DESCRIPTION
This commit updates the styling for the 'getting started' page. The previously hardcoded height has been removed in the index.tsx file, and updated to support dynamic heights based on viewport height (vh) in styles.module.css. This change is to ensure proper display and layout on screens with different resolutions or aspect ratios. Padding-top is also configured to maintain the structure and layout of the page.