### PR TITLE
Add clearComponents functionality to clear turrets action

### DIFF
--- a/src/pages/turret-planner/index.tsx
+++ b/src/pages/turret-planner/index.tsx
@@ -13,6 +13,7 @@ import {clearTurrets} from "~reducers/turret";
 import {IntlContext} from "~contexts/intl";
 import {ComponentsTable} from "~components/components-table";
 import {CargoTable} from "~components/cargo-table";
+import {clearComponents} from "~reducers/component.ts";
 
 export function TurretPlannerPage() {
     const [isClosePage, setClose] = useState(false);
@@ -44,6 +45,7 @@ export function TurretPlannerPage() {
 
     function handleClearTurrets() {
         dispatcher(clearTurrets());
+        dispatcher(clearComponents());
     }
 
     return (


### PR DESCRIPTION
In the TurretPlannerPage component, the 'clearComponents' action has been imported from the 'component' reducer. This action is then dispatched inside the 'handleClearTurrets' function to ensure that components are also cleared whenever turrets are cleared. This change helps to maintain data consistency by ensuring that component data doesn't linger when related turrets are removed.