### PR TITLE
Remove onerror localStorage clearing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,10 +49,6 @@ const router = createBrowserRouter([
     }
 ]);
 
-window.onerror = function () {
-    localStorage.clear();
-};
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <StrictMode>
         <CssVarsProvider theme={theme} defaultMode="dark" modeStorageKey={CACHE_THEME} disableNestedContext>


### PR DESCRIPTION
Deleted the onerror function that was clearing the localStorage. This is no longer necessary as we have addressed the root of the issue that was causing errors and required the localStorage to be cleared.