### PR TITLE
Enable dynamic text resize for small screens

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,11 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="CssUnknownTarget" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="46" name="TypeScript" />
+      </Languages>
+    </inspection_tool>
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.2",
+        "react-responsive": "^9.0.2",
         "react-router": "^6.15.0",
         "react-router-dom": "^6.15.0",
         "web-vitals": "^3.4.0"
@@ -2006,6 +2007,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -2648,6 +2654,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -2902,6 +2913,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "node_modules/merge2": {
@@ -3297,6 +3316,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.2.tgz",
+      "integrity": "sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.15.0.tgz",
@@ -3497,6 +3533,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.2",
+    "react-responsive": "^9.0.2",
     "react-router": "^6.15.0",
     "react-router-dom": "^6.15.0",
     "web-vitals": "^3.4.0"

--- a/src/components/cargo-table/cargo-quantity/index.tsx
+++ b/src/components/cargo-table/cargo-quantity/index.tsx
@@ -1,6 +1,8 @@
 import {Stack, Typography} from "@mui/joy";
 import {CargoItemAction} from "~components/cargo-table/cargo-action";
 import {ComponentType} from "~constants/enums/components.ts";
+import {useTheme} from "@mui/joy/styles";
+import {useMediaQuery} from "react-responsive";
 
 type Props = {
     value: number;
@@ -8,12 +10,22 @@ type Props = {
 }
 
 export function CargoItemQuantity(props: Props) {
+    const theme = useTheme();
     const value = props.value ?? 0;
+    const isSmallScreen = useMediaQuery({
+        query: `(max-width: ${theme.breakpoints.values.sm}px)`
+    });
+
+    let fontSize: 'md' | number = 'md';
+
+    if (isSmallScreen) {
+        fontSize = 12;
+    }
 
     return (
         <td align="right" style={{paddingLeft: 0, paddingRight: 8}}>
             <Stack direction="row" spacing={1} justifyContent="flex-end" alignItems="center">
-                <Typography color="primary" fontFamily="monospace">
+                <Typography fontSize={fontSize} color="primary" fontFamily="monospace">
                     {value.toLocaleString()}
                 </Typography>
                 <CargoItemAction type={props.type}/>

--- a/src/components/cargo-table/cargo-type/index.tsx
+++ b/src/components/cargo-table/cargo-type/index.tsx
@@ -4,15 +4,26 @@ import {ComponentType} from "~constants/enums/components";
 import {ComponentsMeta} from "~constants/meta/components";
 import {IntlContext} from "~contexts/intl";
 import styles from "./styles.module.css";
+import {useTheme} from "@mui/joy/styles";
+import {useMediaQuery} from 'react-responsive';
 
 type Props = {
     type: ComponentType;
 }
 
 export function CargoItemType(props: Props) {
+    const theme = useTheme();
     const intlContext = useContext(IntlContext);
+    const isSmallScreen = useMediaQuery({
+        query: `(max-width: ${theme.breakpoints.values.sm}px)`
+    });
 
+    let fontSize: 'md' | number = 'md';
     let color: "danger" | "warning" | undefined;
+
+    if (isSmallScreen) {
+        fontSize = 12;
+    }
 
     if (ComponentsMeta[props.type].dangerous) {
         color = "danger";
@@ -28,7 +39,7 @@ export function CargoItemType(props: Props) {
                 <img className={styles.icon}
                      src={ComponentsMeta[props.type].icon}
                      alt={intlContext.text("COMPONENT", props.type)}/>
-                <Typography key={props.type} color={color}>
+                <Typography fontSize={fontSize} color={color}>
                     {intlContext.text("COMPONENT", props.type)}
                 </Typography>
             </Stack>

--- a/src/components/components-table/component-quantity/index.tsx
+++ b/src/components/components-table/component-quantity/index.tsx
@@ -5,6 +5,8 @@ import {RootState} from "~store";
 import {computeQuantity} from "~utils/computations/quantity";
 import {ComponentType} from "~constants/enums/components";
 import {ComponentItemAction} from "~components/components-table/component-action";
+import {useTheme} from "@mui/joy/styles";
+import {useMediaQuery} from "react-responsive";
 
 type Props = {
     type: ComponentType;
@@ -12,10 +14,20 @@ type Props = {
 }
 
 export function ComponentItemQuantity(props: Props) {
+    const theme = useTheme();
     const cargo = useSelector((state: RootState) => state.cargo);
     const quantity = useMemo(() => computeQuantity(cargo.entities[props.type], props.value), [cargo, props]);
+    const isSmallScreen = useMediaQuery({
+        query: `(max-width: ${theme.breakpoints.values.sm}px)`
+    });
 
+    let fontSize: 'md' | number = 'md';
     let color: "warning" | "primary" = "primary";
+
+    if (isSmallScreen) {
+        fontSize = 12;
+    }
+
     if (quantity !== props.value) {
         color = "warning";
     }
@@ -23,7 +35,7 @@ export function ComponentItemQuantity(props: Props) {
     return (
         <td align="right" style={{paddingLeft: 0, paddingRight: 8}}>
             <Stack direction="row" spacing={1} justifyContent="flex-end" alignItems="center">
-                <Typography color={color} fontFamily="monospace">
+                <Typography fontSize={fontSize} color={color} fontFamily="monospace">
                     {quantity.toLocaleString()}
                 </Typography>
                 <ComponentItemAction type={props.type}/>

--- a/src/components/components-table/component-type/index.tsx
+++ b/src/components/components-table/component-type/index.tsx
@@ -8,15 +8,21 @@ import {useDispatch, useSelector} from "react-redux";
 import {RootState} from "~store";
 import {SxProps} from "@mui/joy/styles/types";
 import {createComponentCheckbox, deleteComponentCheckbox} from "~reducers/checkbox.ts";
+import {useTheme} from "@mui/joy/styles";
+import {useMediaQuery} from "react-responsive";
 
 type Props = {
     type: ComponentType,
 }
 
 export function ComponentItemType(props: Props) {
+    const theme = useTheme();
     const intlContext = useContext(IntlContext);
     const checkbox = useSelector((state: RootState) => state.checkbox);
     const dispatch = useDispatch();
+    const isSmallScreen = useMediaQuery({
+        query: `(max-width: ${theme.breakpoints.values.sm}px)`
+    });
 
     function handleCheckbox() {
         if (checkbox.entities[props.type]) {
@@ -26,8 +32,13 @@ export function ComponentItemType(props: Props) {
         }
     }
 
-    const sx: SxProps = {textDecoration: "none", opacity: 1}
+    const sx: SxProps = {textDecoration: "none", opacity: 1};
+    let fontSize: 'md' | number = 'md';
     let color: "danger" | "warning" | undefined;
+
+    if (isSmallScreen) {
+        fontSize = 12;
+    }
 
     if (ComponentsMeta[props.type].dangerous) {
         color = "danger";
@@ -53,7 +64,7 @@ export function ComponentItemType(props: Props) {
                     <img className={styles.icon}
                          src={ComponentsMeta[props.type].icon}
                          alt={intlContext.text("COMPONENT", props.type)}/>
-                    <Typography key={props.type} color={color} sx={sx}>
+                    <Typography fontSize={fontSize} color={color} sx={sx}>
                         {intlContext.text("COMPONENT", props.type)}
                     </Typography>
                 </Stack>

--- a/src/components/components-table/index.tsx
+++ b/src/components/components-table/index.tsx
@@ -12,6 +12,8 @@ import {clearComponents} from "~reducers/component.ts";
 import {clearCargoComponents} from "~reducers/cargo.ts";
 import {clearComponentsCheckbox} from "~reducers/checkbox.ts";
 import styles from './styles.module.css';
+import {useTheme} from "@mui/joy/styles";
+import {useMediaQuery} from "react-responsive";
 
 export function ComponentsTable() {
     const [components, setComponents] = useState<Record<ComponentType, number>>({} as Record<ComponentType, number>)
@@ -22,12 +24,16 @@ export function ComponentsTable() {
         volume: 0
     })
 
+    const theme = useTheme();
     const intlContext = useContext(IntlContext);
     const componentStore = useSelector((state: RootState) => state.component);
     const turretStore = useSelector((state: RootState) => state.turret);
     const cargoStore = useSelector((state: RootState) => state.cargo);
     const worker = useMemo(() => computationWorker, []);
     const dispatch = useDispatch();
+    const isSmallScreen = useMediaQuery({
+        query: `(max-width: ${theme.breakpoints.values.sm}px)`
+    });
 
     useEffect(() => {
         async function performComputation() {
@@ -45,6 +51,12 @@ export function ComponentsTable() {
 
     if (Object.keys(components).length === 0) {
         return null;
+    }
+
+    let fontSize: 'md' | number = 'md';
+
+    if (isSmallScreen) {
+        fontSize = 12;
     }
 
     return (
@@ -80,16 +92,20 @@ export function ComponentsTable() {
                 <Divider inset="context" sx={{mt: 0}}/>
                 <Stack>
                     <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
-                        <Typography level="body-sm">{intlContext.text("UI", "estimated-price")}</Typography>
+                        <Typography fontSize={fontSize}
+                                    level="body-sm">{intlContext.text("UI", "estimated-price")}</Typography>
                         <Stack direction="row">
-                            <Typography level="body-sm">~¢</Typography>
-                            <Typography level="body-sm">{computations.avg.toLocaleString()}</Typography>
+                            <Typography fontSize={fontSize} level="body-sm">~¢</Typography>
+                            <Typography fontSize={fontSize}
+                                        level="body-sm">{computations.avg.toLocaleString()}</Typography>
                         </Stack>
                     </Stack>
                     <Divider/>
                     <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
-                        <Typography level="body-sm">{intlContext.text("UI", "estimated-volume")}</Typography>
-                        <Typography level="body-sm">{computations.volume.toLocaleString()}</Typography>
+                        <Typography fontSize={fontSize}
+                                    level="body-sm">{intlContext.text("UI", "estimated-volume")}</Typography>
+                        <Typography fontSize={fontSize}
+                                    level="body-sm">{computations.volume.toLocaleString()}</Typography>
                     </Stack>
                 </Stack>
             </CardOverflow>


### PR DESCRIPTION
Enabled dynamic text resizing for smaller screens to enhance the user experience of the application on mobile devices. In the updated files, we are now using a media query to check the screen size and adjust the font size accordingly. 'react-responsive' library was added to the project to enable the use of media queries.

Changes were implemented in the components files and settings in the .idea/inspectionProfiles/Project_Default.xml file were updated to reduce the chance of duplicating the similar code pieces.