### PR TITLE
Update Typography component width in components-table

### DIFF
--- a/src/components/components-table/component-type/index.tsx
+++ b/src/components/components-table/component-type/index.tsx
@@ -68,7 +68,7 @@ export function ComponentItemType(props: Props) {
                 <Box sx={{opacity: checkbox.entities[props.type] ? '.5' : '1'}}>
                     <ComponentIcon type={props.type}/>
                 </Box>
-                <Typography fontSize={fontSize} color={color} sx={sx}>
+                <Typography fontSize={fontSize} color={color} sx={sx} width="max-content">
                     {intlContext.text("COMPONENT", props.type)}
                 </Typography>
                 {!isSmallScreen && (


### PR DESCRIPTION
In the `src/components/components-table/component-type/index.tsx` file, the width attribute of the Typography component was set to a new value 'max-content'. This was done to ensure the text within the component does not overflow its parent element or obscure any elements that are supposed to be displayed alongside it, promoting better UI structure and user experience.