### PR TITLE
Update CSS mix-blend-mode and simplify react component

### DIFF
--- a/src/components/component-icon/styles.module.css
+++ b/src/components/component-icon/styles.module.css
@@ -1,5 +1,5 @@
 .icon {
-    mix-blend-mode: difference;
+    mix-blend-mode: exclusion;
     width: 24px;
     height: 24px;
 }

--- a/src/components/components-table/component-type/index.tsx
+++ b/src/components/components-table/component-type/index.tsx
@@ -1,6 +1,6 @@
 import {ComponentType} from "~constants/enums/components";
 import {MouseEvent, useContext} from "react";
-import {Box, IconButton, Stack, Typography} from "@mui/joy";
+import {IconButton, Stack, Typography} from "@mui/joy";
 import {ComponentsMeta} from "~constants/meta/components";
 import {IntlContext} from "~contexts/intl";
 import {useDispatch, useSelector} from "react-redux";
@@ -65,9 +65,7 @@ export function ComponentItemType(props: Props) {
     return (
         <td onClick={handleCheckbox} style={{paddingLeft: 8, paddingRight: 0, cursor: "pointer", userSelect: "none"}}>
             <Stack direction="row" alignItems="center" spacing={.5}>
-                <Box sx={{opacity: checkbox.entities[props.type] ? '.5' : '1'}}>
-                    <ComponentIcon type={props.type}/>
-                </Box>
+                <ComponentIcon type={props.type}/>
                 <Typography fontSize={fontSize} color={color} sx={sx} width="max-content">
                     {intlContext.text("COMPONENT", props.type)}
                 </Typography>

--- a/src/components/turret-icon/styles.module.css
+++ b/src/components/turret-icon/styles.module.css
@@ -1,5 +1,5 @@
 .icon {
-    mix-blend-mode: difference;
+    mix-blend-mode: exclusion;
     width: 32px;
     height: 32px;
 }


### PR DESCRIPTION
This commit modifies the mix-blend-mode applied to the .icon in two CSS modules from 'difference' to 'exclusion' for consistent rendering across different browsers. The change impacts the 'component-icon' and 'turret-icon' component styles. In addition, the 'component-type' react component has been simplified to a cleaner syntax by removing the unnecessary Box wrapper around the ComponentIcon. This doesn't affect the functionality but improves readability and performance.