### PR TITLE
Remove redundant turret and component types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,29 +1,5 @@
 import {ComponentType} from "~constants/enums/components.ts";
-import {TurretType} from "~constants/enums/turrets.ts";
 import {SellerType} from "~constants/enums/sellers.ts";
-
-export interface Component {
-    key: ComponentType;
-    quantity: number;
-}
-
-export interface Turret {
-    key: TurretType;
-    quantity: number;
-    price: number;
-    components: Record<ComponentType, number>;
-}
-
-export interface TurretPayload {
-    id: string;
-    data: Turret;
-}
-
-export interface ComponentPayload {
-    turretId: string;
-    type: ComponentType;
-    data: number;
-}
 
 export type TurretMetaType = { icon: string, components: ComponentType[] };
 export type ComponentMetaType = {


### PR DESCRIPTION
Simplified the types/index.ts file by removing the Turret, Component, TurretPayload, and ComponentPayload interface type definitions. These types were unnecessarily complicating the structure and weren't being utilized effectively in the codebase. The refactor leads to simpler, easier-to-read code.