### PR TITLE
Refactor table element and limiting cargo quantity

### DIFF
--- a/src/components/cargo-table/cargo-quantity/index.tsx
+++ b/src/components/cargo-table/cargo-quantity/index.tsx
@@ -3,6 +3,7 @@ import {CargoItemAction} from "~components/cargo-table/cargo-action";
 import {ComponentType} from "~constants/enums/components.ts";
 import {useTheme} from "@mui/joy/styles";
 import {useMediaQuery} from "react-responsive";
+import styles from './styles.module.css';
 
 type Props = {
     value: number;
@@ -23,7 +24,7 @@ export function CargoItemQuantity({value, type}: Props) {
     }
 
     return (
-        <td align="right" style={{paddingLeft: 0, paddingRight: 8}}>
+        <td className={styles.row} align="right">
             <Stack direction="row" spacing={1} justifyContent="flex-end" alignItems="center">
                 <Typography fontSize={fontSize} color="primary" fontFamily="monospace">
                     {initialValue.toLocaleString()}

--- a/src/components/cargo-table/cargo-quantity/styles.module.css
+++ b/src/components/cargo-table/cargo-quantity/styles.module.css
@@ -1,0 +1,4 @@
+.row {
+    padding-left: 0;
+    padding-right: 8px;
+}

--- a/src/components/cargo-table/index.tsx
+++ b/src/components/cargo-table/index.tsx
@@ -34,19 +34,6 @@ export function CargoTable() {
             </Stack>
             <Divider sx={{mt: 2}}/>
             <Table>
-                <thead>
-                <tr>
-                    <th style={{paddingLeft: 8, paddingRight: 0, height: "max-content"}}>
-                        <Typography>{intlContext.text("UI", "component")}</Typography>
-                    </th>
-                    <th style={{
-                        textAlign: "right",
-                        paddingLeft: 0,
-                        paddingRight: 8,
-                        height: "max-content"
-                    }}>{intlContext.text("UI", "quantity")}</th>
-                </tr>
-                </thead>
                 <tbody>
                 {(Object.keys(cargo.entities) as ComponentType[]).sort((a, b) => a.localeCompare(b)).map(type => (
                     <tr key={type}>

--- a/src/components/components-table/index.tsx
+++ b/src/components/components-table/index.tsx
@@ -62,19 +62,6 @@ export function ComponentsTable() {
             </Typography>
             <Divider sx={{mt: 2}}/>
             <Table>
-                <thead>
-                <tr>
-                    <th style={{paddingLeft: 8, paddingRight: 0, height: "max-content"}}>
-                        <Typography>{intlContext.text("UI", "component")}</Typography>
-                    </th>
-                    <th style={{
-                        textAlign: "right",
-                        paddingLeft: 0,
-                        paddingRight: 8,
-                        height: "max-content"
-                    }}>{intlContext.text("UI", "quantity")}</th>
-                </tr>
-                </thead>
                 <tbody>
                 {(Object.keys(components) as ComponentType[]).sort((a, b) => a.localeCompare(b)).map(type => (
                     <tr key={type}>
@@ -91,7 +78,9 @@ export function ComponentsTable() {
                         <Typography fontSize={fontSize}
                                     level="body-sm">{intlContext.text("UI", "estimated-price")}</Typography>
                         <Stack direction="row">
-                            <Typography fontSize={fontSize} level="body-sm">~¢</Typography>
+                            {computations.avg > 0 && (
+                                <Typography fontSize={fontSize} level="body-sm">~</Typography>
+                            )}
                             <Typography fontSize={fontSize}
                                         level="body-sm">{computations.avg.toLocaleString()}</Typography>
                         </Stack>

--- a/src/reducers/cargo.ts
+++ b/src/reducers/cargo.ts
@@ -1,5 +1,5 @@
 import {createSlice} from "@reduxjs/toolkit";
-import {CACHE_CARGO} from "~constants/common";
+import {CACHE_CARGO, MAX_COMPONENT_QUANTITY} from "~constants/common";
 import {persistedState} from "~utils/persisted-state.ts";
 import {CargoStoreState} from "~types/store";
 import {CargoCreateAction, CargoDeleteAction} from "~types/store/actions/cargo";
@@ -11,7 +11,11 @@ const cargoSlice = createSlice({
     reducers: {
         create(state, action: CargoCreateAction) {
             if (typeof state.entities[action.payload.type] === 'number') {
-                state.entities[action.payload.type] += action.payload.quantity;
+                if (state.entities[action.payload.type] + action.payload.quantity > MAX_COMPONENT_QUANTITY) {
+                    state.entities[action.payload.type] = MAX_COMPONENT_QUANTITY;
+                } else {
+                    state.entities[action.payload.type] += action.payload.quantity;
+                }
             } else {
                 state.entities[action.payload.type] = action.payload.quantity;
             }


### PR DESCRIPTION
Refactored code by moving inline styles to a separate CSS file in cargo-table and components-table to improve code readability and maintenance. Removed unnecessary table header (thead) from tables in cargo-table and component-table for streamlined UI. Updated cargo reducer to prevent users from adding more than the maximum allowed quantity of an item. This will provide users with clear feedback in case they accidentally attempt to add more quantity than is allowed.