### PR TITLE
Optimize card display for zero values

### DIFF
--- a/src/components/components-table/index.tsx
+++ b/src/components/components-table/index.tsx
@@ -71,29 +71,33 @@ export function ComponentsTable() {
                 ))}
                 </tbody>
             </Table>
-            <CardOverflow variant="soft" color="neutral" sx={{borderRadius: 0}}>
-                <Divider inset="context" sx={{mt: 0}}/>
-                <Stack>
-                    <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
-                        <Typography fontSize={fontSize}
-                                    level="body-sm">{intlContext.text("UI", "estimated-price")}</Typography>
-                        <Stack direction="row">
-                            {computations.avg > 0 && (
-                                <Typography fontSize={fontSize} level="body-sm">~</Typography>
-                            )}
+            {(computations.avg > 0 || computations.volume > 0) && (
+                <CardOverflow variant="soft" color="neutral" sx={{borderRadius: 0}}>
+                    <Divider inset="context" sx={{mt: 0}}/>
+                    <Stack>
+                        <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
                             <Typography fontSize={fontSize}
-                                        level="body-sm">{computations.avg.toLocaleString()}</Typography>
+                                        level="body-sm">{intlContext.text("UI", "estimated-price")}</Typography>
+                            <Stack direction="row">
+                                {computations.avg > 0 && (
+                                    <Typography fontSize={fontSize} level="body-sm">~</Typography>
+                                )}
+                                <Typography fontSize={fontSize}
+                                            level="body-sm">{computations.avg.toLocaleString()}</Typography>
+                            </Stack>
+                        </Stack>
+                        <Divider/>
+                        <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
+                            <Typography fontSize={fontSize}
+                                        level="body-sm">{intlContext.text("UI", "estimated-volume")}</Typography>
+                            <Typography fontSize={fontSize}
+                                        level="body-sm">{computations.volume.toLocaleString()}</Typography>
                         </Stack>
                     </Stack>
-                    <Divider/>
-                    <Stack direction="row" justifyContent="space-between" sx={{p: 1}}>
-                        <Typography fontSize={fontSize}
-                                    level="body-sm">{intlContext.text("UI", "estimated-volume")}</Typography>
-                        <Typography fontSize={fontSize}
-                                    level="body-sm">{computations.volume.toLocaleString()}</Typography>
-                    </Stack>
-                </Stack>
-            </CardOverflow>
+                </CardOverflow>
+            )}
+
+            <Divider/>
             <Box sx={{p: 1}}>
                 <Typography level="body-sm">
                     <b>Avorion Tools</b> is a community work, and not officially created or maintained by <Link


### PR DESCRIPTION
This commit introduces an improvement to the UI of the components-table. Specifically, the computation card that was previously always visible, will now only be displayed when there are non-zero computed values (i.e., avg or volume calculations). This should enhance the clarity and cleanliness of the interface, keeping unnecessary information from being displayed when it's not required.