### PR TITLE
Refactor animations to use constants

### DIFF
--- a/src/components/turret-item/turret-header/index.tsx
+++ b/src/components/turret-item/turret-header/index.tsx
@@ -8,7 +8,12 @@ import {TurretEntity} from "~types/store/entity.ts";
 import {deleteComponent, updateComponent} from "~reducers/component.ts";
 import {RootState} from "~store";
 import {ComponentType} from "~constants/enums/components.ts";
-import {MIN_COMPONENT_QUANTITY, MIN_TURRET_PRICE, MIN_TURRET_QUANTITY,} from "~constants/common.ts";
+import {
+    MIN_COMPONENT_QUANTITY,
+    MIN_TURRET_PRICE,
+    MIN_TURRET_QUANTITY,
+    PAGE_ANIMATION_CONTROLS,
+} from "~constants/common.ts";
 import {clearComponentsCheckbox} from "~reducers/checkbox.ts";
 import {TurretIcon} from "~components/turret-icon";
 import {AnimationControlContext} from "~contexts/animation-control";
@@ -27,18 +32,11 @@ export function TurretHeader({id, entity}: Props) {
 
     function handleDeleteTurret() {
         if (Object.keys(turretStore.entities).length === 1) {
-            if (controls) {
-                controls
-                    .start({
-                        opacity: 0,
-                        transition: {duration: .150}
-                    })
-                    .then(() => {
-                        dispatch(clearComponentsCheckbox());
-                        dispatch(deleteComponent({identity: id}));
-                        dispatch(deleteTurret({identity: id}));
-                    });
-            }
+            controls?.start(PAGE_ANIMATION_CONTROLS).then(() => {
+                dispatch(clearComponentsCheckbox());
+                dispatch(deleteComponent({identity: id}));
+                dispatch(deleteTurret({identity: id}));
+            });
         } else {
             clearTurretState();
         }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -14,3 +14,10 @@ export const CACHE_LANG = "cache:v3:lang";
 export const CACHE_TURRETS = "cache:v3:turrets";
 export const CACHE_COMPONENTS = "cache:v3:components";
 export const CACHE_THEME = "cache:v3:theme";
+
+export const PAGE_ANIMATION_CONTROLS = {
+    opacity: 0,
+    transition: {duration: .150}
+}
+export const PAGE_ANIMATION_INITIAL = {opacity: 1}
+export const PAGE_ANIMATION_EXIT = {opacity: 0}

--- a/src/pages/getting-started/index.tsx
+++ b/src/pages/getting-started/index.tsx
@@ -11,6 +11,7 @@ import {TurretPicker} from "~components/turret-picker";
 import {Center} from "~components/center";
 import {AnimationControlContext} from "~contexts/animation-control";
 import {motion} from "framer-motion";
+import {PAGE_ANIMATION_CONTROLS, PAGE_ANIMATION_EXIT, PAGE_ANIMATION_INITIAL} from "~constants/common.ts";
 
 export function GettingStartedPage() {
     const intlContext = useContext(IntlContext);
@@ -20,14 +21,10 @@ export function GettingStartedPage() {
 
     useEffect(() => {
         if (Object.keys(turretStore.entities).length > 0) {
-            controls?.start({
-                opacity: 0,
-                transition: {duration: .150}
+            controls?.start(PAGE_ANIMATION_CONTROLS).then(() => {
+                window.scrollTo(0, 0);
+                navigate("/turret-planner", {replace: true});
             })
-                .then(() => {
-                    window.scrollTo(0, 0);
-                    navigate("/turret-planner", {replace: true});
-                })
         }
     }, [controls, navigate, turretStore]);
 
@@ -38,8 +35,8 @@ export function GettingStartedPage() {
     return (
         <motion.div
             animate={controls}
-            initial={{opacity: 1}}
-            exit={{opacity: 0}}
+            initial={PAGE_ANIMATION_INITIAL}
+            exit={PAGE_ANIMATION_EXIT}
             style={{height: 'calc(100vh - 90px)', overflow: 'hidden'}}
         >
             <Box className={componentClasses}>

--- a/src/pages/turret-planner/index.tsx
+++ b/src/pages/turret-planner/index.tsx
@@ -16,6 +16,7 @@ import {clearComponents} from "~reducers/component.ts";
 import {clearComponentsCheckbox} from "~reducers/checkbox.ts";
 import {motion} from "framer-motion";
 import {AnimationControlContext} from "~contexts/animation-control";
+import {PAGE_ANIMATION_CONTROLS, PAGE_ANIMATION_EXIT, PAGE_ANIMATION_INITIAL} from "~constants/common.ts";
 
 export function TurretPlannerPage() {
     const intlContext = useContext(IntlContext);
@@ -32,14 +33,7 @@ export function TurretPlannerPage() {
     }, [navigate, turretStore]);
 
     function handleExitAnimation() {
-        if (controls) {
-            controls
-                .start({
-                    opacity: 0,
-                    transition: {duration: .150}
-                })
-                .then(handleClearTurrets);
-        }
+        controls?.start(PAGE_ANIMATION_CONTROLS).then(handleClearTurrets);
     }
 
     function handleClearTurrets() {
@@ -55,8 +49,8 @@ export function TurretPlannerPage() {
     return (
         <motion.div
             animate={controls}
-            initial={{opacity: 1}}
-            exit={{opacity: 0}}
+            initial={PAGE_ANIMATION_INITIAL}
+            exit={PAGE_ANIMATION_EXIT}
         >
             <Container maxWidth={false} sx={{pb: 2}} className={styles.component}>
                 <Box className={animationClasses}>


### PR DESCRIPTION
Animations across different components were refactored to use predefined constants in 'common.ts' file. Previously, animation parameters were hard-coded in each component, which is not a maintainable approach considering scale. Now, we have PAGE_ANIMATION_CONTROLS, PAGE_ANIMATION_INITIAL, and PAGE_ANIMATION_EXIT constants defined in 'common.ts', imported and used in each component, thus standardizing animation behavior and simplifying future updates.