### PR TITLE
Replace div with Box for better styling support

### DIFF
--- a/src/components/components-table/component-type/index.tsx
+++ b/src/components/components-table/component-type/index.tsx
@@ -1,6 +1,6 @@
 import {ComponentType} from "~constants/enums/components";
 import {MouseEvent, useContext} from "react";
-import {IconButton, Typography} from "@mui/joy";
+import {Box, IconButton, Typography} from "@mui/joy";
 import {ComponentsMeta} from "~constants/meta/components";
 import {IntlContext} from "~contexts/intl";
 import {useDispatch, useSelector} from "react-redux";
@@ -73,7 +73,7 @@ export function ComponentItemType({type}: Props) {
                 userSelect: "none",
             }}
         >
-            <div className={styles.component}>
+            <Box className={styles.component} sx={sx}>
                 <ComponentIcon type={type}/>
 
                 <Typography fontSize={fontSize} color={color} sx={sx}>
@@ -82,6 +82,7 @@ export function ComponentItemType({type}: Props) {
 
                 {!isSmallScreen && (
                     <IconButton
+                        disabled={!!checkbox.entities[type]}
                         size="sm"
                         title={intlContext.text("UI", "copy")}
                         onClick={handleCopyText(intlContext.text("COMPONENT", type))}
@@ -89,7 +90,7 @@ export function ComponentItemType({type}: Props) {
                         <CopyAll/>
                     </IconButton>
                 )}
-            </div>
+            </Box>
         </td>
     );
 }


### PR DESCRIPTION
A div element was replaced with a Box component from '@mui/joy' in the component-type/index.tsx file to allow for better styling support. An 'sx' prop was also added to the Box component to enable the use of the theme-based style function. Additionally, a 'disabled' prop was added to the IconButton component, which dynamically disables the button based on the existence of an entity in the checkbox.entities array.